### PR TITLE
Remove colon from widget heading for consistency

### DIFF
--- a/goobi-viewer-core/WebContent/resources/components/widgets/widget_chronology.xhtml
+++ b/goobi-viewer-core/WebContent/resources/components/widgets/widget_chronology.xhtml
@@ -17,7 +17,7 @@
         <div class="widget-chronology-slider">
             <!-- LABEL -->
             <div class="widget-chronology-slider__item chronology-slider-label">
-                #{msg.widgetChronology_label}:
+                #{msg.widgetChronology_label}
             </div>
             
             <div class="widget-chronology-slider__item chronology-slider-actions">


### PR DESCRIPTION
Other sidebar headings don't have a hard coded colon. This should better be handled in the messages properties files.